### PR TITLE
Fix output of fio, fieri (was fio, feri)

### DIFF
--- a/src/commands/dictionary_form.adb
+++ b/src/commands/dictionary_form.adb
@@ -448,7 +448,13 @@ begin
             if de.Part.v.Con.var = 2  then
                ox(2) := add(de.Stems(2), "re");
             elsif de.Part.v.Con.var = 3  then
-               ox(2) := add(de.Stems(2), "eri");
+               -- Special case for fio, fieri: it follows the usual
+               -- conjugation everywhere except for present infinitive
+               if Trim(de.Stems(2)) = "f" then
+                  ox(2) := add(de.Stems(2), "ieri");
+               else
+                  ox(2) := add(de.Stems(2), "eri");
+               end if;
             elsif de.Part.v.Con.var = 4  then
                ox(2) := add(de.Stems(2), "ire");
             else


### PR DESCRIPTION
This is, as far as I know, the only special case of the 3 3 group: the semideponenit `fio, fieri` instead of the regular `fio, *feri` as was printed before.

I fixed this with a branch in the code instead of making a special subgroup just for one word.
