### PR TITLE
Make identifiers more self-explanatory.

### DIFF
--- a/src/latin_utils/latin_utils-preface.adb
+++ b/src/latin_utils/latin_utils-preface.adb
@@ -14,44 +14,56 @@
 -- All parts of the WORDS system, source code and data files, are made freely
 -- available to anyone who wishes to use them, for whatever purpose.
 
+with Ada.Integer_Text_IO;
 with Latin_Utils.Config;
 use Latin_Utils;
 package body Latin_Utils.Preface is
 
-   procedure Put(s : String) is
+   ---------------------------------------------------------------------------
+
+   procedure Put (Item : String) is
    begin
-      if not Config.suppress_preface  then
-         Ada.Text_IO.Put(Ada.Text_IO.Current_Output, s);
+      if not Config.suppress_preface then
+         Ada.Text_IO.Put (Ada.Text_IO.Current_Output, Item);
       end if;
    end Put;
 
-   procedure Set_Col(pc : Ada.Text_IO.Positive_Count) is
+   ---------------------------------------------------------------------------
+
+   procedure Set_Col (To : Ada.Text_IO.Positive_Count) is
    begin
-      if not Config.suppress_preface  then
-         Ada.Text_IO.Set_Col(Ada.Text_IO.Current_Output, pc);
+      if not Config.suppress_preface then
+         Ada.Text_IO.Set_Col (Ada.Text_IO.Current_Output, To);
       end if;
    end Set_Col;
 
-   procedure Put_Line(s : String) is
+   ---------------------------------------------------------------------------
+
+   procedure Put_Line (Item : String) is
    begin
-      if not Config.suppress_preface  then
-         Ada.Text_IO.Put_Line(Ada.Text_IO.Current_Output, s);
+      if not Config.suppress_preface then
+         Ada.Text_IO.Put_Line (Ada.Text_IO.Current_Output, Item);
       end if;
    end Put_Line;
 
-   procedure New_Line(spacing  : Ada.Text_IO.Positive_Count := 1) is
+   ---------------------------------------------------------------------------
+
+   procedure New_Line (Spacing : Ada.Text_IO.Positive_Count := 1) is
    begin
-      if not Config.suppress_preface  then
-         Ada.Text_IO.New_Line(Ada.Text_IO.Current_Output, spacing);
+      if not Config.suppress_preface then
+         Ada.Text_IO.New_Line (Ada.Text_IO.Current_Output, Spacing);
       end if;
    end New_Line;
 
-   procedure Put(n : Integer; width : Ada.Text_IO.Field := Integer'Width) is
-      package Integer_IO is new Ada.Text_IO.Integer_IO(Integer);
+   ---------------------------------------------------------------------------
+
+   procedure Put (Item : Integer; Width : Ada.Text_IO.Field := Integer'Width) is
    begin
-      if not Config.suppress_preface  then
-         Integer_IO.Put(Ada.Text_IO.Current_Output, n, width);
+      if not Config.suppress_preface then
+         Ada.Integer_Text_IO.Put (Ada.Text_IO.Current_Output, Item, Width);
       end if;
    end Put;
+
+   ---------------------------------------------------------------------------
 
 end Latin_Utils.Preface;

--- a/src/latin_utils/latin_utils-preface.ads
+++ b/src/latin_utils/latin_utils-preface.ads
@@ -16,9 +16,15 @@
 
 with Ada.Text_IO;
 package Latin_Utils.Preface is
-   procedure Put(s: String);
-   procedure Set_Col(pc : Ada.Text_IO.Positive_Count);
-   procedure Put_Line(s : String);
-   procedure New_Line(spacing  : Ada.Text_IO.Positive_Count := 1);
-   procedure Put(n : Integer; width : Ada.Text_IO.Field := Integer'Width);
+
+   ---------------------------------------------------------------------------
+
+   procedure Put (Item: String);
+   procedure Set_Col (To : Ada.Text_IO.Positive_Count);
+   procedure Put_Line (Item : String);
+   procedure New_Line (Spacing  : Ada.Text_IO.Positive_Count := 1);
+   procedure Put (Item : Integer; Width : Ada.Text_IO.Field := Integer'Width);
+
+   ---------------------------------------------------------------------------
+
 end Latin_Utils.Preface;


### PR DESCRIPTION
Use language predefined instantiation of Ada.Text_IO.Integer_IO instead of instantiating it on our own.
Additionally make casing conform to standard Ada practice.

Signed-off-by: darkestkhan darkestkhan@gmail.com
