### PR TITLE
Add Dockerfile and documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM debian:jessie
+MAINTAINER Ivan Valle <ivanmartinvalle@gmail.com>
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    gnat \
+    gprbuild \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+ADD . /root/.whitakers-words
+
+WORKDIR /root/.whitakers-words
+
+RUN make
+
+ENTRYPOINT ["./bin/words"]

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Build-time Dependencies
 * GPRBuild
 * gnat
 
+Running in Docker
+=======================
+
+    $ docker build -t whitakers-words .
+    $ docker run -it whitakers-words
+
 Licensing
 =========
 


### PR DESCRIPTION
I created a Dockerfile for easy access to building and running this beautiful tool on all operating systems. Usage is include in README.md (assumes some familiarity with [Docker](https://www.docker.com/)).
