### PR TITLE
typos; link to documentation

### DIFF
--- a/ADDONS.LAT
+++ b/ADDONS.LAT
@@ -46,7 +46,7 @@
 --  when applied to different parts.  "sub" applied to an adjective
 --  adds the meaning "somewhat", when applied to a verb it means "under".
 --  The parts of speech (from and to) are listed on the second line,
---  but are always the same.  The redundency is the result of a generality
+--  but are always the same.  The redundancy is the result of a generality
 --  built into the data structure initially and never changed.
 --  
 --  The third line gives the meaning, using 78 characters or less.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ Usage
 Documentation
 =============
 
-See the wordsdoc.htm file included.
+See the HOWTO.txt file included, 
+and documentation on the [Project Website](http://mk270.github.io/whitakers-words/operational.html)
+
 
 Build-time Dependencies
 =======================

--- a/src/support_utils/support_utils-developer_parameters.adb
+++ b/src/support_utils/support_utils-developer_parameters.adb
@@ -158,7 +158,7 @@ package body Support_Utils.Developer_Parameters is
 
    For_Word_List_Check_Help : constant Help_Type :=  (
      "This option works in conjunction with DO_ONLY_INITIAL_WORD to allow   ",
-     "the processing of scanned dictionarys or text word lists.  It accepts ",
+     "the processing of scanned dictionaries or text word lists.  It accepts",
      "only the forms common in dictionary entries, like NOM S for N or ADJ, ",
      "or PRES ACTIVE IND 1 S for V.  It is be used only with DO_INITIAL_WORD",
      "The default choice is N(o), but it can be turned on with a Y(es).     ");
@@ -222,9 +222,9 @@ package body Support_Utils.Developer_Parameters is
    Do_Medieval_Tricks_Help : constant Help_Type :=  (
      "This option instructs the program, when it is unable to find a proper ",
      "match in the dictionary, and after various prefixes and suffixes, and ",
-     "tring every Classical Latin trick it can think of, to go to a few that",
-     "are usually only found in medieval Latin, replacements of caul -> col,",
-     "st -> est, z -> di, ix -> is, nct -> nt.  It also tries some things   ",
+     "trying every Classical Latin trick it can think of, to go to a few    ",
+     "that are usually only found in medieval Latin, replacements of z -> di",
+     "caul -> col, st -> est, ix -> is, nct -> nt. It also tries some things",
      "like replacing doubled consonants in classical with a single one.     ",
      "Together these tricks are useful, but may give False Positives (>20%).",
      "This option is only available if the general DO_TRICKS is chosen.     ",
@@ -236,25 +236,25 @@ package body Support_Utils.Developer_Parameters is
 
    Do_Syncope_Help : constant Help_Type :=  (
      "This option instructs the program to postulate that syncope of        ",
-     "perfect stem verbs may have occured (e.g, aver -> ar in the perfect), ",
+     "perfect stem verbs may have occurred (e.g, aver -> ar in the perfect),",
      "and to try various possibilities for the insertion of a removed 'v'.  ",
      "To do this it has to fully process the modified candidates, which can ",
-     "have a consderable impact on the speed of processind a large file.    ",
-     "However, this trick seldom producesa False Positive, and syncope is   ",
+     "have a considerable impact on the speed of processing a large file.   ",
+     "However, this trick seldom produces a False Positive, and syncope is  ",
      "very common in Latin (first year texts excepted).  Default is Y(es).  ",
      "This processing is turned off with the choice of N(o).                ");
 
    Do_Two_Words_Help : constant Help_Type :=  (
-     "There are some few common Lain expressions that combine two inflected ",
+     "There are some few common Latin expressions that combine two inflected",
      "words (e.g. respublica, paterfamilias).  There are numerous examples  ",
      "of numbers composed of two words combined together.                   ",
      "Sometimes a text or inscription will have words run together.         ",
      "When WORDS is unable to reach a satisfactory solution with all other  ",
      "tricks, as a last stab it will try to break the Input into two words. ",
-     "This most often fails.  Even if mechnically successful, the result is ",
+     "This most often fails.  Even if mechanically successful, the result is",
      "usually False and must be examined by the user.  If the result is     ",
      "correct, it is probably clear to the user.  Otherwise,  beware.  .    ",
-     "Since this is a last chanceand infrequent, the default is Y(es);      ",
+     "Since this is a last chance and infrequent, the default is Y(es);     ",
      "This processing is turned off with the choice of N(o).                ");
 
    Include_Unknown_Context_Help : constant Help_Type :=  (
@@ -296,17 +296,17 @@ package body Support_Utils.Developer_Parameters is
 
    Do_I_For_J_Help : constant Help_Type :=  (
      "This option instructs the program to modify the Output so that the j/J",
-     "is represented as i/I.  The consonant i was Writen as j in cursive in ",
+     "is represented as i/I.  The consonant i was Written as j in cursive in",
      "Imperial times and called i longa, and often rendered as j in medieval",
      "times.  The capital is usually rendered as I, as in inscriptions.     ",
      "If this is NO/FALSE, the Output will have the same Character as Input.",
      "The program default, and the dictionary convention is to retain the j.",
-     "Reset if this ia unsuitable for your application. The default is N(o).");
+     "Reset if this is unsuitable for your application. The default is N(o).");
 
    Do_U_For_V_Help : constant Help_Type :=  (
      "This option instructs the program to modify the Output so that the u  ",
-     "is represented as v.  The consonant u was Writen sometimes as uu.     ",
-     "The pronounciation was as current w, and important for poetic meter.  ",
+     "is represented as v.  The consonant u was Written sometimes as uu.    ",
+     "The pronunciation was as current w, and important for poetic meter.   ",
      "With the printing press came the practice of distinguishing consonant ",
      "u with the Character v, and was common for centuries.  The practice of",
      "using only u has been adopted in some 20th century publications (OLD),",
@@ -314,7 +314,7 @@ package body Support_Utils.Developer_Parameters is
      "V in any case, as it was and is in inscriptions (easier to chisel).   ",
      "If this is NO/FALSE, the Output will have the same Character as Input.",
      "The program default, and the dictionary convention is to retain the v.",
-     "Reset If this ia unsuitable for your application. The default is N(o).");
+     "Reset If this is unsuitable for your application. The default is N(o).");
 
    Pause_In_Screen_Output_Help : constant Help_Type :=  (
      "This option instructs the program to pause in Output on the screen    ",
@@ -354,11 +354,11 @@ package body Support_Utils.Developer_Parameters is
      "This option instructs the program to invite the user to modify the    ",
      "meaning displayed on a word translation.  This is only active if the  ",
      "program is not using an (@) Input file!  These changes are Put into   ",
-     "the dictionary right then and permenently, and are available from     ",
+     "the dictionary right then and permanently, and are available from     ",
      "then on, in this session, and all later sessions.   Unfortunately,    ",
      "these changes will not survive the replacement of the dictionary by a ",
      "new version from the developer.  Changes can only be recovered by     ",
-     "considerable prcessing by the deneloper, and should be left there.    ",
+     "considerable processing by the developer, and should be left there.   ",
      "This option is only for experienced users and should remain off.      ",
      "                                          The default is N(o).        ",
      "      ------    NOT AVAILABLE IN THIS VERSION   -------               ");

--- a/src/support_utils/support_utils-word_parameters.adb
+++ b/src/support_utils/support_utils-word_parameters.adb
@@ -75,7 +75,7 @@ package body Support_Utils.Word_Parameters is
      "Note that poets are likely to employ unusual words and inflections for",
      "various reasons.  These may be trimmed out if this parameter in on.   ",
      "When in English mode, trim just reduces the Output to the top six     ",
-     "results, if there are that many.  Asterix means there are more        ",
+     "results, if there are that many.  Asterix means there are more.       ",
      "                                                The default is Y(es)  ");
 
    Have_Output_File_Help : constant Help_Type :=  (
@@ -97,13 +97,13 @@ package body Support_Utils.Word_Parameters is
      "thereby capturing only certain desired results.  If the option        ",
      "HAVE_OUTPUT_FILE is off, the user will not be given a chance to turn  ",
      "this one on.  Only for INTERACTIVE running.         Default is N(o).  ",
-     "This works in English mode, but Output in somewhat diffeent so far.   ");
+     "This works in English mode, but Output in somewhat different so far.  ");
 
    Do_Unknowns_Only_Help : constant Help_Type :=  (
      "This option instructs the program to only Output those words that it  ",
      "cannot resolve.  Of course, it has to do processing on all words, but ",
      "those that are found (with prefix/suffix, if that option in on) will  ",
-     "be ignored.  The purpose of this option is t allow a quick look to    ",
+     "be ignored.  The purpose of this option is to allow a quick look to   ",
      "determine if the dictionary and process is going to do an acceptable  ",
      "job on the current text.  It also allows the user to assemble a list  ",
      "of unknown words to look up manually, and perhaps augment the system  ",
@@ -118,7 +118,7 @@ package body Support_Utils.Word_Parameters is
      "This option instructs the program to Write all unresolved words to a  ",
      "UNKNOWNS file named " & Unknowns_Full_Name
      & (21 + Unknowns_Full_Name'Length .. 70 => ' '),
-     "With this option on , the file of unknowns is written, even though    ",
+     "With this option on, the file of unknowns is written, even though     ",
      "the main Output contains both known and unknown (unresolved) words.   ",
      "One may wish to save the unknowns for later analysis, testing, or to  ",
      "form the basis for dictionary additions.  When this option is turned  ",
@@ -133,7 +133,7 @@ package body Support_Utils.Word_Parameters is
      "longer than three letters is a proper name.  As no dictionary can be  ",
      "expected to account for many proper names, many such occur that would ",
      "be called UNKNOWN.  This contaminates the Output in most cases, and   ",
-     "it is often convenient to ignore these sperious UNKNOWN hits.  This   ",
+     "it is often convenient to ignore these spurious UNKNOWN hits.  This   ",
      "option implements that mode, and calls such words proper names.       ",
      "Any proper names that are in the dictionary are handled in the normal ",
      "manner.                                The default is Y(es).          ");
@@ -142,9 +142,9 @@ package body Support_Utils.Word_Parameters is
      "This option instructs the program to assume that any all caps word    ",
      "is a proper name or similar designation.  This convention is often    ",
      "used to designate speakers in a discussion or play.  No dictionary can",
-     "claim to be exaustive on proper names, so many such occur that would  ",
+     "claim to be exhaustive on proper names, so many such occur that would ",
      "be called UNKNOWN.  This contaminates the Output in most cases, and   ",
-     "it is often convenient to ignore these sperious UNKNOWN hits.  This   ",
+     "it is often convenient to ignore these spurious UNKNOWN hits.  This   ",
      "option implements that mode, and calls such words names.  Any similar ",
      "designations that are in the dictionary are handled in the normal     ",
      "manner, as are normal words in all caps.    The default is Y(es).     ");
@@ -152,7 +152,7 @@ package body Support_Utils.Word_Parameters is
    Do_Compounds_Help : constant Help_Type :=  (
      "This option instructs the program to look ahead for the verb TO_BE (or",
      "iri) when it finds a verb participle, with the expectation of finding ",
-     "a compound perfect tense or periphastic.  This option can also be a   ",
+     "a compound perfect tense or periphrastic.  This option can also be a  ",
      "trimming of the output, in that VPAR that do not fit (not NOM) will be",
      "excluded, possible interpretations are lost.  Default choice is Y(es).",
      "This processing is turned off with the choice of N(o).                ");
@@ -175,7 +175,7 @@ package body Support_Utils.Word_Parameters is
      "try every dirty Latin trick it can think of, mainly common letter     ",
      "replacements like cl -> cul, vul -> vol, ads -> ass, inp -> imp, etc. ",
      "Together these tricks are useful, but may give False Positives (>10%).",
-     "They provide for recognized varients in classical spelling.  Most of  ",
+     "They provide for recognized variants in classical spelling.  Most of  ",
      "the texts with which this program will be used have been well edited  ",
      "and standardized in spelling.  Now, moreover,  the dictionary is being",
      "populated to such a state that the hit rate on tricks has fallen to a ",
@@ -209,7 +209,7 @@ package body Support_Utils.Word_Parameters is
    Do_Examples_Help : constant Help_Type :=  (
      "This option instructs the program to provide examples of usage of the ",
      "cases/tenses/etc. that were constructed.  The default choice is N(o). ",
-     "This produces lengthly Output and is turned on with the choice Y(es). ");
+     "This produces lengthy Output and is turned on with the choice Y(es).  ");
 
    Do_Only_Meanings_Help : constant Help_Type :=  (
      "This option instructs the program to only Output the MEANING for a    ",


### PR DESCRIPTION
- README.md referenced file wordsdoc.htm which we do not have, so I replaced it with a link to the documentation on the web
- I corrected some typos in `src/support_utils/support_utils-{developer,word}_parameters.adb`   (I manually went through both files with aspell, but changed only the most obviously wrong cases)