### PR TITLE
Pearse code: new code 07 for tricks and compounds

### DIFF
--- a/src/words_engine/words_engine-list_package.adb
+++ b/src/words_engine/words_engine-list_package.adb
@@ -295,7 +295,7 @@ package body Words_Engine.List_Package is
          when Yyy => Put_Word_Meaning (Xp.Yyy_Meaning, Trick); --  Syncope
          when Ppp => Put_Word_Meaning (Xp.Ppp_Meaning, Trick); --  Compounds
          when Addons =>
-            Put_Pearse_Code (Output, Trick);
+            Put_Pearse_Code (Output, Affix_meaning);
             Put_Meaning (Output, Means (Integer (Dm.MNPC)));
             Ada.Text_IO.New_Line (Output);
          when others =>

--- a/src/words_engine/words_engine-pearse_code.ads
+++ b/src/words_engine/words_engine-pearse_code.ads
@@ -27,7 +27,8 @@ package Words_Engine.Pearse_Code is
      Gloss,         -- 03
      Unknowns_2,    -- 04
      Affix,         -- 05
-     Trick          -- 06
+     Affix_meaning, -- 06
+     Trick          -- 07
    );
 
    function Format (S : Symbol) return String;


### PR DESCRIPTION
This solves the issue with double meaning of code 06 that I mention in https://github.com/mk270/whitakers-words/issues/77#issuecomment-325585617

I am not sure about backward compatibility though. While I think that semantically it makes sense to introduce code 07 -- and it makes using the Pearse codes easier for future users -- it will break compatibility for anyone who has written a script that works with the original "double meaning" code 06.