### PR TITLE
Failed to compile until removal of this line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ PROGRAMMES := bin/words bin/makedict bin/wakedict bin/makestem bin/makeefil bin/
 all: $(PROGRAMMES) data
 
 $(PROGRAMMES):
-	$(BUILD) -j$(nproc) -Pwords $(notdir $@)
+	$(BUILD) -j15 -Pwords $(notdir $@)
 
 bin/sorter:
-	$(BUILD) -j$(nproc) -Ptools $(notdir $@)
+	$(BUILD) -j15 -Ptools $(notdir $@)
 
 DICTFILE.GEN: DICTLINE.GEN bin/wakedict
 	echo g | bin/wakedict $< > /dev/null

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ PROGRAMMES := bin/words bin/makedict bin/wakedict bin/makestem bin/makeefil bin/
 all: $(PROGRAMMES) data
 
 $(PROGRAMMES):
-	$(BUILD) -j15 -Pwords $(notdir $@)
+	$(BUILD) -j4 -Pwords $(notdir $@)
 
 bin/sorter:
-	$(BUILD) -j15 -Ptools $(notdir $@)
+	$(BUILD) -j4 -Ptools $(notdir $@)
 
 DICTFILE.GEN: DICTLINE.GEN bin/wakedict
 	echo g | bin/wakedict $< > /dev/null

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ PROGRAMMES := bin/words bin/makedict bin/wakedict bin/makestem bin/makeefil bin/
 all: $(PROGRAMMES) data
 
 $(PROGRAMMES):
-	$(BUILD) -j4 -Pwords $(notdir $@)
+	$(BUILD) -j$(nproc) -Pwords $(notdir $@)
 
 bin/sorter:
-	$(BUILD) -j4 -Ptools $(notdir $@)
+	$(BUILD) -j$(nproc) -Ptools $(notdir $@)
 
 DICTFILE.GEN: DICTLINE.GEN bin/wakedict
 	echo g | bin/wakedict $< > /dev/null

--- a/src/words_engine/words_engine-parse.adb
+++ b/src/words_engine/words_engine-parse.adb
@@ -37,7 +37,6 @@ with Words_Engine.Pearse_Code; use Words_Engine.Pearse_Code;
 pragma Elaborate (Support_Utils.Word_Parameters);
 package body Words_Engine.Parse
 is
-   use Inflections_Package.Integer_IO;
    use Ada.Text_IO;
 
    package Word_Container is new Vectors (Natural, Unbounded_String);


### PR DESCRIPTION
I could not get this to compile without removing this line, it looks like it is recognizing declensions and conjugations fine without it.   After I removed it and compiled I did these tests just to be sure....

christopher@dadscomputer:~/Projects/whitakers-words* master
$matutinum
bash: matutinum: command not found
christopher@dadscomputer:~/Projects/whitakers-words* master
$./bin/words matutinum
matutin.um           ADJ    1 1 NOM S N POS             
matutin.um           ADJ    1 1 VOC S N POS             
matutin.um           ADJ    1 1 ACC S M POS             
matutin.um           ADJ    1 1 ACC S N POS             
matutinus, matutina, matutinum  ADJ   [XXXDX]    lesser
early; of the (early) morning;

christopher@dadscomputer:~/Projects/whitakers-words* master
$./bin/words confessoris
confessor.is         N      3 1 GEN S M                 
confessor.is         N      3 1 ACC P M                   uncommon
confessor, confessoris  N (3rd) M   [DEXES]    Late  uncommon
confessor of Christianity; martyr; lower clergy; pious monk; confessor (modern)
*
christopher@dadscomputer:~/Projects/whitakers-words* master
$inducas
bash: inducas: command not found
christopher@dadscomputer:~/Projects/whitakers-words* master
$./bin/words inducas
induc.as             V      3 1 PRES ACTIVE  SUB 2 S    
induco, inducere, induxi, inductus  V (3rd)   [XXXBX]  
lead in, bring in (performers); induce, influence; introduce;

christopher@dadscomputer:~/Projects/whitakers-words* master
$adoret
bash: adoret: command not found
christopher@dadscomputer:~/Projects/whitakers-words* master
$./bin/words adoret
ador.et              V      1 1 PRES ACTIVE  SUB 3 S    
adoro, adorare, adoravi, adoratus  V (1st) TRANS   [XXXBO]  
honor, adore, worship, pay homage, reverence; beg, plead with, appeal to;

These all look correct once I removed the line.    