### PR TITLE
fix exception when using DO_STEMS_FOR_UNKNOWN with screen output

### DIFF
--- a/src/words_engine/words_engine-list_package.adb
+++ b/src/words_engine/words_engine-list_package.adb
@@ -763,7 +763,8 @@ package body Words_Engine.List_Package is
 
    -- update local dictionary, and handling of caps, temporarily disabled
    procedure List_Unknowns
-     (Input_Line :        String;
+     (Output     :        Ada.Text_IO.File_Type;
+      Input_Line :        String;
       Raw_Word   :        String)
    is
       use Ada.Text_IO;
@@ -777,18 +778,18 @@ package body Words_Engine.List_Package is
          Ada.Text_IO.Put_Line (Output, "    ========   UNKNOWN    ");
       else              --  Just screen Output
          if Words_Mdev (Do_Pearse_Codes) then
-            Ada.Text_IO.Put ("04 ");
+            Ada.Text_IO.Put (Output, "04 ");
          end if;
-         Ada.Text_IO.Put (Raw_Word);
+         Ada.Text_IO.Put (Output, Raw_Word);
          Ada.Text_IO.Set_Col (30);
-         Ada.Text_IO.Put_Line ("    ========   UNKNOWN    ");
+         Ada.Text_IO.Put_Line (Output, "    ========   UNKNOWN    ");
       end if;
 
       if Words_Mode (Write_Unknowns_To_File)  then
          if Words_Mdev (Include_Unknown_Context) or
            Words_Mdev (Do_Only_Initial_Word)
          then
-            Ada.Text_IO.Put_Line (Input_Line);
+            Ada.Text_IO.Put_Line (Output, Input_Line);
             Ada.Text_IO.Put_Line (Unknowns, Input_Line);
          end if;
          Put_Pearse_Code (Unknowns, Unknowns_2);
@@ -930,7 +931,7 @@ package body Words_Engine.List_Package is
       --                    LIST_SWEEP  -  PA_LAST = 0
       if WA.Unknowns then
          --  WORD failed
-         List_Unknowns (Input_Line, Raw_Word);
+         List_Unknowns (Output, Input_Line, Raw_Word);
       end if;
 
       --  Exit if UNKNOWNS ONLY (but had to do STATS above)


### PR DESCRIPTION
If DO_STEMS_FOR_UNKNOWN is enabled and WRITE_OUTPUT_TO_FILE is not, the program will terminate on a STATUS_ERROR because List_Package.List_Stems does not pass Word_Parameters.Output : Aliased Text_IO.File_Type to List_Package.List_Unknowns.

  Example:
  =>aa
  Unexpected exception in LIST_STEMS processing aa
  raised ADA.IO_EXCEPTIONS.STATUS_ERROR : System.File_IO.Check_Write_Status: file not open
  Exception in PARSE_LINE processing aa

The lines 766-67 and 934 of this commit are the easiest resolution (expressly passing Output).

While we're here, I suggest passing Output expressly at lines 781, 783, 785 and 792.