### PR TITLE
Use plain ASCII when possible

### DIFF
--- a/LICENCE.txt
+++ b/LICENCE.txt
@@ -1,7 +1,7 @@
 
 WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 
-Copyright William A. Whitaker (1936–2010)
+Copyright William A. Whitaker (1936-2010)
 
 This is a free program, which means it is proper to copy it and pass
 it on to your friends. Consider it a developmental item for which

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Licensing
 
 WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 
-Copyright William A. Whitaker (1936–2010)
+Copyright William A. Whitaker (1936-2010)
 
 This is a free program, which means it is proper to copy it and pass
 it on to your friends. Consider it a developmental item for which

--- a/src/commands/banner.adb
+++ b/src/commands/banner.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/commands/banner.ads
+++ b/src/commands/banner.ads
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/commands/makedict.adb
+++ b/src/commands/makedict.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/commands/makedict_main.adb
+++ b/src/commands/makedict_main.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/commands/makeefil.adb
+++ b/src/commands/makeefil.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/commands/makeewds.adb
+++ b/src/commands/makeewds.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/commands/makeinfl.adb
+++ b/src/commands/makeinfl.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/commands/makestem.adb
+++ b/src/commands/makestem.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/commands/meanings.adb
+++ b/src/commands/meanings.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/commands/process_input.adb
+++ b/src/commands/process_input.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/commands/wakedict.adb
+++ b/src/commands/wakedict.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/commands/weed.adb
+++ b/src/commands/weed.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/commands/weed_all.adb
+++ b/src/commands/weed_all.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/commands/words.adb
+++ b/src/commands/words.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/commands/words_main.adb
+++ b/src/commands/words_main.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-config.adb.in
+++ b/src/latin_utils/latin_utils-config.adb.in
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-config.ads
+++ b/src/latin_utils/latin_utils-config.ads
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-dictionary_package-adjective_entry_io.adb
+++ b/src/latin_utils/latin_utils-dictionary_package-adjective_entry_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-dictionary_package-adverb_entry_io.adb
+++ b/src/latin_utils/latin_utils-dictionary_package-adverb_entry_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-dictionary_package-conjunction_entry_io.adb
+++ b/src/latin_utils/latin_utils-dictionary_package-conjunction_entry_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-dictionary_package-dictionary_entry_io.adb
+++ b/src/latin_utils/latin_utils-dictionary_package-dictionary_entry_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-dictionary_package-interjection_entry_io.adb
+++ b/src/latin_utils/latin_utils-dictionary_package-interjection_entry_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-dictionary_package-kind_entry_io.adb
+++ b/src/latin_utils/latin_utils-dictionary_package-kind_entry_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-dictionary_package-noun_entry_io.adb
+++ b/src/latin_utils/latin_utils-dictionary_package-noun_entry_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-dictionary_package-numeral_entry_io.adb
+++ b/src/latin_utils/latin_utils-dictionary_package-numeral_entry_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-dictionary_package-parse_record_io.adb
+++ b/src/latin_utils/latin_utils-dictionary_package-parse_record_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-dictionary_package-part_entry_io.adb
+++ b/src/latin_utils/latin_utils-dictionary_package-part_entry_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-dictionary_package-preposition_entry_io.adb
+++ b/src/latin_utils/latin_utils-dictionary_package-preposition_entry_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-dictionary_package-pronoun_entry_io.adb
+++ b/src/latin_utils/latin_utils-dictionary_package-pronoun_entry_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-dictionary_package-propack_entry_io.adb
+++ b/src/latin_utils/latin_utils-dictionary_package-propack_entry_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-dictionary_package-translation_record_io.adb
+++ b/src/latin_utils/latin_utils-dictionary_package-translation_record_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-dictionary_package-verb_entry_io.adb
+++ b/src/latin_utils/latin_utils-dictionary_package-verb_entry_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-dictionary_package.adb
+++ b/src/latin_utils/latin_utils-dictionary_package.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-dictionary_package.ads
+++ b/src/latin_utils/latin_utils-dictionary_package.ads
@@ -120,7 +120,7 @@ package Latin_Utils.Dictionary_Package is
         G,  --  Gildersleeve + Lodge, Latin Grammar 1895 (G+L)
         H,  --  Collatinus Dictionary by Yves Ouvrard
         I,  --  Leverett, F.P., Lexicon of the Latin Language, Boston 1845
-        J,  --  Bracton: De Legibus Et Consuetudinibus Angliæ
+        J,  --  Bracton: De Legibus Et Consuetudinibus Angliae
         K,  --  Calepinus Novus, modern Latin, by Guy Licoppe (Cal)
         L,  --  Lewis, C.S., Elementary Latin Dictionary 1891
         M,  --  Latham, Revised Medieval Word List, 1980 (Latham)

--- a/src/latin_utils/latin_utils-general.adb
+++ b/src/latin_utils/latin_utils-general.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-general.ads
+++ b/src/latin_utils/latin_utils-general.ads
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-inflections_package-adjective_record_io.adb
+++ b/src/latin_utils/latin_utils-inflections_package-adjective_record_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-inflections_package-adverb_record_io.adb
+++ b/src/latin_utils/latin_utils-inflections_package-adverb_record_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-inflections_package-conjunction_record_io.adb
+++ b/src/latin_utils/latin_utils-inflections_package-conjunction_record_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-inflections_package-decn_record_io.adb
+++ b/src/latin_utils/latin_utils-inflections_package-decn_record_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-inflections_package-ending_record_io.adb
+++ b/src/latin_utils/latin_utils-inflections_package-ending_record_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-inflections_package-inflection_record_io.adb
+++ b/src/latin_utils/latin_utils-inflections_package-inflection_record_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-inflections_package-interjection_record_io.adb
+++ b/src/latin_utils/latin_utils-inflections_package-interjection_record_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-inflections_package-noun_record_io.adb
+++ b/src/latin_utils/latin_utils-inflections_package-noun_record_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-inflections_package-numeral_record_io.adb
+++ b/src/latin_utils/latin_utils-inflections_package-numeral_record_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-inflections_package-prefix_record_io.adb
+++ b/src/latin_utils/latin_utils-inflections_package-prefix_record_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-inflections_package-preposition_record_io.adb
+++ b/src/latin_utils/latin_utils-inflections_package-preposition_record_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-inflections_package-pronoun_record_io.adb
+++ b/src/latin_utils/latin_utils-inflections_package-pronoun_record_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-inflections_package-propack_record_io.adb
+++ b/src/latin_utils/latin_utils-inflections_package-propack_record_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-inflections_package-quality_record_io.adb
+++ b/src/latin_utils/latin_utils-inflections_package-quality_record_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-inflections_package-stem_type_io.adb
+++ b/src/latin_utils/latin_utils-inflections_package-stem_type_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-inflections_package-suffix_record_io.adb
+++ b/src/latin_utils/latin_utils-inflections_package-suffix_record_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-inflections_package-supine_record_io.adb
+++ b/src/latin_utils/latin_utils-inflections_package-supine_record_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-inflections_package-tackon_record_io.adb
+++ b/src/latin_utils/latin_utils-inflections_package-tackon_record_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-inflections_package-verb_record_io.adb
+++ b/src/latin_utils/latin_utils-inflections_package-verb_record_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-inflections_package-vpar_record_io.adb
+++ b/src/latin_utils/latin_utils-inflections_package-vpar_record_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-inflections_package.adb
+++ b/src/latin_utils/latin_utils-inflections_package.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-inflections_package.ads
+++ b/src/latin_utils/latin_utils-inflections_package.ads
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-latin_file_names.ads
+++ b/src/latin_utils/latin_utils-latin_file_names.ads
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-preface.adb
+++ b/src/latin_utils/latin_utils-preface.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-preface.ads
+++ b/src/latin_utils/latin_utils-preface.ads
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-strings_package.adb
+++ b/src/latin_utils/latin_utils-strings_package.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils-strings_package.ads
+++ b/src/latin_utils/latin_utils-strings_package.ads
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/latin_utils/latin_utils.ads
+++ b/src/latin_utils/latin_utils.ads
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/support_utils/support_utils-addons_package-prefix_entry_io.adb
+++ b/src/support_utils/support_utils-addons_package-prefix_entry_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/support_utils/support_utils-addons_package-suffix_entry_io.adb
+++ b/src/support_utils/support_utils-addons_package-suffix_entry_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/support_utils/support_utils-addons_package-tackon_entry_io.adb
+++ b/src/support_utils/support_utils-addons_package-tackon_entry_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/support_utils/support_utils-addons_package-target_entry_io.adb
+++ b/src/support_utils/support_utils-addons_package-target_entry_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/support_utils/support_utils-addons_package.adb
+++ b/src/support_utils/support_utils-addons_package.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/support_utils/support_utils-addons_package.ads
+++ b/src/support_utils/support_utils-addons_package.ads
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/support_utils/support_utils-char_utils.adb
+++ b/src/support_utils/support_utils-char_utils.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/support_utils/support_utils-char_utils.ads
+++ b/src/support_utils/support_utils-char_utils.ads
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/support_utils/support_utils-developer_parameters.adb
+++ b/src/support_utils/support_utils-developer_parameters.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/support_utils/support_utils-developer_parameters.ads
+++ b/src/support_utils/support_utils-developer_parameters.ads
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/support_utils/support_utils-dictionary_form.adb
+++ b/src/support_utils/support_utils-dictionary_form.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/support_utils/support_utils-line_stuff-prefix_line_io.adb
+++ b/src/support_utils/support_utils-line_stuff-prefix_line_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/support_utils/support_utils-line_stuff-suffix_line_io.adb
+++ b/src/support_utils/support_utils-line_stuff-suffix_line_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/support_utils/support_utils-line_stuff-tackon_line_io.adb
+++ b/src/support_utils/support_utils-line_stuff-tackon_line_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/support_utils/support_utils-line_stuff-unique_entry_io.adb
+++ b/src/support_utils/support_utils-line_stuff-unique_entry_io.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/support_utils/support_utils-line_stuff.adb
+++ b/src/support_utils/support_utils-line_stuff.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/support_utils/support_utils-line_stuff.ads
+++ b/src/support_utils/support_utils-line_stuff.ads
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/support_utils/support_utils-uniques_package.ads
+++ b/src/support_utils/support_utils-uniques_package.ads
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/support_utils/support_utils-word_parameters.adb
+++ b/src/support_utils/support_utils-word_parameters.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/support_utils/support_utils-word_parameters.ads
+++ b/src/support_utils/support_utils-word_parameters.ads
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/support_utils/support_utils-word_support_package.adb
+++ b/src/support_utils/support_utils-word_support_package.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/support_utils/support_utils-word_support_package.ads
+++ b/src/support_utils/support_utils-word_support_package.ads
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/support_utils/support_utils.ads
+++ b/src/support_utils/support_utils.ads
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/tools/check.adb
+++ b/src/tools/check.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/tools/dictflag.adb
+++ b/src/tools/dictflag.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/tools/dictord.adb
+++ b/src/tools/dictord.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/tools/dictpage.adb
+++ b/src/tools/dictpage.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/tools/diffdict.adb
+++ b/src/tools/diffdict.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/tools/dups.adb
+++ b/src/tools/dups.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/tools/fil2dict.adb
+++ b/src/tools/fil2dict.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/tools/fixord.adb
+++ b/src/tools/fixord.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/tools/invert.adb
+++ b/src/tools/invert.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/tools/invstems.adb
+++ b/src/tools/invstems.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/tools/linedict.adb
+++ b/src/tools/linedict.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/tools/linefile.adb
+++ b/src/tools/linefile.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/tools/listdict.adb
+++ b/src/tools/listdict.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/tools/listord.adb
+++ b/src/tools/listord.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/tools/number.adb
+++ b/src/tools/number.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/tools/oners.adb
+++ b/src/tools/oners.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/tools/page2htm.adb
+++ b/src/tools/page2htm.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/tools/patch.adb
+++ b/src/tools/patch.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/tools/slash.adb
+++ b/src/tools/slash.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/tools/sorter.adb
+++ b/src/tools/sorter.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/tools/uniqpage.adb
+++ b/src/tools/uniqpage.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/words_engine/words_engine-english_support_package.adb
+++ b/src/words_engine/words_engine-english_support_package.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/words_engine/words_engine-english_support_package.ads
+++ b/src/words_engine/words_engine-english_support_package.ads
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/words_engine/words_engine-explanation_package.ads
+++ b/src/words_engine/words_engine-explanation_package.ads
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/words_engine/words_engine-initialization.adb
+++ b/src/words_engine/words_engine-initialization.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/words_engine/words_engine-initialization.ads
+++ b/src/words_engine/words_engine-initialization.ads
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/words_engine/words_engine-list_package.adb
+++ b/src/words_engine/words_engine-list_package.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/words_engine/words_engine-list_package.ads
+++ b/src/words_engine/words_engine-list_package.ads
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/words_engine/words_engine-list_sweep.adb
+++ b/src/words_engine/words_engine-list_sweep.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/words_engine/words_engine-list_sweep.ads
+++ b/src/words_engine/words_engine-list_sweep.ads
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/words_engine/words_engine-parse.adb
+++ b/src/words_engine/words_engine-parse.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/words_engine/words_engine-parse.ads
+++ b/src/words_engine/words_engine-parse.ads
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/words_engine/words_engine-pearse_code.adb
+++ b/src/words_engine/words_engine-pearse_code.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/words_engine/words_engine-pearse_code.ads
+++ b/src/words_engine/words_engine-pearse_code.ads
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/words_engine/words_engine-put_example_line.adb
+++ b/src/words_engine/words_engine-put_example_line.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/words_engine/words_engine-put_stat.adb
+++ b/src/words_engine/words_engine-put_stat.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/words_engine/words_engine-roman_numerals_package.adb
+++ b/src/words_engine/words_engine-roman_numerals_package.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/words_engine/words_engine-roman_numerals_package.ads
+++ b/src/words_engine/words_engine-roman_numerals_package.ads
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/words_engine/words_engine-search_english.adb
+++ b/src/words_engine/words_engine-search_english.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/words_engine/words_engine-trick_tables.adb
+++ b/src/words_engine/words_engine-trick_tables.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/words_engine/words_engine-trick_tables.ads
+++ b/src/words_engine/words_engine-trick_tables.ads
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/words_engine/words_engine-tricks.adb
+++ b/src/words_engine/words_engine-tricks.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/words_engine/words_engine-tricks.ads
+++ b/src/words_engine/words_engine-tricks.ads
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/words_engine/words_engine-word_package.adb
+++ b/src/words_engine/words_engine-word_package.adb
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/words_engine/words_engine-word_package.ads
+++ b/src/words_engine/words_engine-word_package.ads
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which

--- a/src/words_engine/words_engine.ads
+++ b/src/words_engine/words_engine.ads
@@ -1,6 +1,6 @@
 -- WORDS, a Latin dictionary, by Colonel William Whitaker (USAF, Retired)
 --
--- Copyright William A. Whitaker (1936–2010)
+-- Copyright William A. Whitaker (1936-2010)
 --
 -- This is a free program, which means it is proper to copy it and pass
 -- it on to your friends. Consider it a developmental item for which


### PR DESCRIPTION
Remove two french characters from DICTLINE.GEN. These were errors, the english word can be encoded in plain ASCII.

In development files, prevent encoding issues by replacing accurate symbols with plain ASCII characters.
(this does not in affect user-facing documentation)
 1936–2010 -> minus sign
 æ         -> ae