### PR TITLE
Fix new warnings detected by GNAT 14

### DIFF
--- a/src/commands/makeewds.adb
+++ b/src/commands/makeewds.adb
@@ -608,7 +608,7 @@ procedure Makeewds is
          if Ewa (Z).W /= Null_Eword then
 
                INNER_LOOP :
-               for ZZ in (Z + 1) .. Ewa'Last loop
+               for ZZ in Z + 1 .. Ewa'Last loop
                   if Ewa (Z).W = Ewa (ZZ).W then
                      Ewa (ZZ).W := Null_Eword;
                   end if;

--- a/src/commands/makeinfl.adb
+++ b/src/commands/makeinfl.adb
@@ -20,7 +20,7 @@ with Latin_Utils.Config;
 with Latin_Utils.Strings_Package; use Latin_Utils.Strings_Package;
 with Latin_Utils.Latin_File_Names; use Latin_Utils.Latin_File_Names;
 with Latin_Utils.Inflections_Package; use Latin_Utils.Inflections_Package;
-with IO_Exceptions;
+with Ada.IO_Exceptions; use Ada;
 with Ada.Exceptions;
 
 procedure Makeinfl is

--- a/src/tools/sorter.adb
+++ b/src/tools/sorter.adb
@@ -16,10 +16,13 @@
 
 with Ada.Integer_Text_IO;
 with Ada.Float_Text_IO;
-with Text_IO;
-with Direct_IO;
+with Ada.Text_IO;
+with Ada.Direct_IO;
 with Latin_Utils.Strings_Package; use Latin_Utils.Strings_Package;
 with Latin_Utils.Dictionary_Package; use Latin_Utils.Dictionary_Package;
+
+use Ada;
+
 procedure Sorter is
    --  This program sorts a file of lines (Strings) on 4 subStrings Mx .. Nx
    --  Sort by Stringwise (different cases), numeric, or POS enumeration


### PR DESCRIPTION
This is what I get without this PR:
```
$ gnat --version && make
GNAT 14.1.0
Copyright (C) 1996-2024, Free Software Foundation, Inc.
This is free software; see the source for copying conditions.
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

sed 's|@datadir@|.|' src/latin_utils/latin_utils-config.adb.in > src/latin_utils/latin_utils-config.adb
gprbuild -p -j4 commands.gpr
Setup
   [mkdir]        object directory for project Latin_Utils
   [mkdir]        library directory for project Latin_Utils
   [mkdir]        object directory for project Support_Utils
   [mkdir]        library directory for project Support_Utils
   [mkdir]        object directory for project Words_Engine
   [mkdir]        library directory for project Words_Engine
   [mkdir]        exec directory for project Commands
Compile
   [Ada]          makedict.adb
   [Ada]          makeefil.adb
   [Ada]          makeewds.adb
   [Ada]          makeinfl.adb
   [Ada]          makestem.adb
makeinfl.adb:23:06: warning: renamed predefined unit is an obsolescent feature (RM J.1) [-gnatwj]
makeewds.adb:611:26: (style) redundant parentheses [-gnatyx]

   compilation of makeewds.adb failed
   compilation of makeinfl.adb failed

gprbuild: *** compilation phase failed
make: *** [Makefile:40: commands] Error 4
```