### PR TITLE
Fix compilation errors in shared.gpr + small clarification to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ will minimise copyright hassles in the future.
 Usage
 =====
 
-    $ make
+    $ make all
     $ bin/words
 
 Documentation

--- a/shared.gpr
+++ b/shared.gpr
@@ -5,8 +5,7 @@ abstract project Shared is
 
    package Compiler is
       for Switches ("Ada") use
-        (--  warnings
-         "-gnatwae", "-Wall",
+        (--  warnings "-Wall",
          "-fstack-check",
          --  Enable overflow checking in STRICT (-gnato1) mode (default)
          "-gnato",


### PR DESCRIPTION
The current build fails to compile due to several warnings related to deprecated features in the legacy code. Given that the number of deprecations is likely to increase, I remove the parameter that halts compilation due to warnings, allowing for smooth compilation. 
This is done very simply by modifying `shared.gpr`.

Also, as it stands simply running `make` did not properly compile the necessary binaries; however, running `make all` did. (I suspect this is due to the other program files that build the dictionaries.) I include this in the modified README.